### PR TITLE
build(docker): 로컬 개발 및 프로덕션용 docker 환경 구성 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# 의존성
+node_modules
+.pnpm-store
+
+# 빌드 아웃풋
+.next
+out
+
+# 환경 변수 (민감 정보)
+.env
+.env.*
+!.env.example
+
+# Git
+.git
+.gitignore
+
+# 에디터
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# 로그
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+# 테스트
+coverage
+__tests__
+*.test.ts
+*.test.tsx
+*.spec.ts
+*.spec.tsx
+
+# 문서
+*.md
+docs/
+
+# CI/CD
+.github
+.vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# ─── Stage 1: deps ────────────────────────────────────────────────────────────
+FROM node:20-alpine AS deps
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install --frozen-lockfile
+
+# ─── Stage 2: builder ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# 빌드 시 필요한 환경변수 (민감 정보는 ARG로 주입)
+ARG NEXT_PUBLIC_GITHUB_USER_NAME
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG SITE_URL=http://localhost:3000
+
+ENV NEXT_PUBLIC_GITHUB_USER_NAME=$NEXT_PUBLIC_GITHUB_USER_NAME
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV SITE_URL=$SITE_URL
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN pnpm build
+
+# ─── Stage 3: runner ──────────────────────────────────────────────────────────
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# standalone 빌드 사용 시 아래 주석 해제 (next.config.js에 output: 'standalone' 추가 필요)
+# COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+# COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+# 일반 빌드
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node_modules/.bin/next", "start"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml* .npmrc ./
+
+# GitHub Packages 인증 토큰 주입 (이미지에 남지 않도록 ARG 사용)
+ARG GITHUB_NPM_TOKEN
+ENV GITHUB_NPM_TOKEN=$GITHUB_NPM_TOKEN
+
+RUN pnpm install
+
+EXPOSE 3001
+
+CMD ["pnpm", "dev:https"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        GITHUB_NPM_TOKEN: ${GITHUB_NPM_TOKEN}
+    container_name: portfolio2-dev
+    ports:
+      - "3001:3001"
+    volumes:
+      # 소스 코드 핫 리로드
+      - .:/app
+      # node_modules는 컨테이너 내부 것을 사용 (호스트 덮어쓰기 방지)
+      - /app/node_modules
+      - /app/.next
+      # HTTPS 인증서 마운트 (읽기 전용)
+      - ./cert:/app/cert:ro
+    env_file:
+      - .env.local
+    environment:
+      - NODE_ENV=development
+      - NEXT_TELEMETRY_DISABLED=1
+      - WATCHPACK_POLLING=true
+    restart: unless-stopped


### PR DESCRIPTION
## 개요
Next.js 포트폴리오 프로젝트에 Docker 기반 로컬 개발 환경을 구성했습니다.
GitHub Packages 인증(`@yeoncheols/portfolio-core-ui`)과 HTTPS 개발 서버(`pnpm dev:https`)를 지원합니다.
프로덕션 멀티스테이지 빌드 Dockerfile도 함께 추가했습니다.

## 변경 사항
- `Dockerfile` — 프로덕션용 멀티스테이지 빌드 (deps → builder → runner)
- `Dockerfile.dev` — 로컬 개발용 이미지 (`pnpm dev:https`, 포트 3001)
- `docker-compose.yml` — 핫 리로드 + HTTPS 인증서 마운트 + GitHub Packages 토큰 주입
- `.dockerignore` — 불필요한 파일 제외 (node_modules, .env, .next 등)

## 테스트 방법
- [ ] `.env.local`에 `GITHUB_NPM_TOKEN` 설정 확인
- [ ] `docker compose up --build` 실행
- [ ] `https://local.ycseng.com:3001` 접속 확인